### PR TITLE
fix(DMVP-9998): bump infra-yaml-loader to 1.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,14 +102,14 @@ git config --global core.hooksPath ./githooks
 
 | Name | Version |
 |------|---------|
-| <a name="provider_tfe"></a> [tfe](#provider\_tfe) | ~> 0.74 |
+| <a name="provider_tfe"></a> [tfe](#provider\_tfe) | 0.79.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_aws_credentials_variable_set"></a> [aws\_credentials\_variable\_set](#module\_aws\_credentials\_variable\_set) | ./modules/variable-set | n/a |
-| <a name="module_infra_yaml_loader"></a> [infra\_yaml\_loader](#module\_infra\_yaml\_loader) | dasmeta/generic/renderer//modules/infra-yaml-loader | 1.2.0 |
+| <a name="module_infra_yaml_loader"></a> [infra\_yaml\_loader](#module\_infra\_yaml\_loader) | dasmeta/generic/renderer//modules/infra-yaml-loader | 1.2.1 |
 | <a name="module_tfe_token_variable_set"></a> [tfe\_token\_variable\_set](#module\_tfe\_token\_variable\_set) | ./modules/variable-set | n/a |
 | <a name="module_workspaces"></a> [workspaces](#module\_workspaces) | ./modules/workspace | n/a |
 

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 module "infra_yaml_loader" {
   #checkov:skip=CKV_TF_1: Registry module source uses version pin (CKV_TF_2)
   source  = "dasmeta/generic/renderer//modules/infra-yaml-loader"
-  version = "1.2.0"
+  version = "1.2.1"
 
   yamldir = var.yamldir
 }

--- a/specs/006-infra-yaml-loader/plan.md
+++ b/specs/006-infra-yaml-loader/plan.md
@@ -1,11 +1,13 @@
 # Plan
 
 1. Add `main.tf` with registry `infra_yaml_loader` module
-   (`dasmeta/generic/renderer//modules/infra-yaml-loader` `1.2.0`).
+   (`dasmeta/generic/renderer//modules/infra-yaml-loader` `1.2.1`).
 2. Replace duplicated YAML locals with `module.infra_yaml_loader` outputs.
-3. Validate existing workspace YAML examples and tests.
+3. Add a repo-local empty-YAML regression test for the shared loader.
+4. Validate existing workspace YAML examples and tests.
 
 ## Validation
 
 - `terraform init` and `terraform validate` in workspace YAML tests
+- `terraform init` and no-op `terraform plan` in `tests/empty-yaml`
 - workspace generation from folder-based YAML layouts

--- a/specs/006-infra-yaml-loader/spec.md
+++ b/specs/006-infra-yaml-loader/spec.md
@@ -11,7 +11,7 @@ Terraform Cloud workspace orchestration in this repository.
 
 ## What
 
-- call `infra-yaml-loader` from registry version `1.2.0`
+- call `infra-yaml-loader` from registry version `1.2.1`
 - remove duplicated YAML locals from the driver root module
 - keep workspace module generation and Terraform Cloud resources unchanged
 
@@ -19,4 +19,5 @@ Terraform Cloud workspace orchestration in this repository.
 
 - driver root module uses `dasmeta/generic/renderer//modules/infra-yaml-loader`
 - duplicated YAML merge/filter locals are removed from `locals.tf`
+- empty YAML files are ignored without loader evaluation failures
 - existing workspace YAML examples continue to work without format changes

--- a/specs/006-infra-yaml-loader/tasks.md
+++ b/specs/006-infra-yaml-loader/tasks.md
@@ -2,4 +2,5 @@
 
 - [x] Add registry `infra_yaml_loader` module to driver `main.tf`.
 - [x] Remove duplicated YAML discovery locals from `locals.tf`.
+- [x] Add repo-local empty-YAML regression test for `infra_yaml_loader` 1.2.1.
 - [ ] Publish driver patch release after merge to `main`.

--- a/tests/empty-yaml/0-setup.tf
+++ b/tests/empty-yaml/0-setup.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = "~> 1.3"
+}
+
+provider "tfe" {
+  token = "test-token"
+}

--- a/tests/empty-yaml/1-example.tf
+++ b/tests/empty-yaml/1-example.tf
@@ -1,0 +1,17 @@
+module "this" {
+  source = "../.."
+
+  org       = "dasmeta-testing"
+  token     = "test-token"
+  yamldir   = "${path.module}/example-infra"
+  rootdir   = "output"
+  targetdir = "${path.module}/output"
+
+  git_enabled = false
+  aws = {
+    enabled = false
+  }
+  tfe_token_variable_set = {
+    enabled = false
+  }
+}

--- a/tests/empty-yaml/README.md
+++ b/tests/empty-yaml/README.md
@@ -1,0 +1,31 @@
+# empty-yaml
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_this"></a> [this](#module\_this) | ../.. | n/a |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+No outputs.
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->


### PR DESCRIPTION
### Summary
Bumps the shared `infra-yaml-loader` registry module from `1.2.0` to `1.2.1` in the TFE Cloud driver and adds a regression test covering empty YAML files.

### Key Changes
- Bump `infra_yaml_loader` module version to `1.2.1` in `main.tf` and `README.md`
- Add `tests/empty-yaml` fixture verifying an empty YAML file doesn't break workspace generation
- Update `specs/006-infra-yaml-loader` plan/spec/tasks to reflect the empty-YAML regression coverage

### Testing/Verification
- `terraform init` and no-op `terraform plan` in `tests/empty-yaml`
